### PR TITLE
Add in building graph releases

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.0.5-development
+2.0.8-development

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add openssl certbot curl --no-cache \
 # Add in the static elements (could also mount these from local filesystem)
 RUN mkdir /nabu
 RUN mkdir /nabu/config
+RUN mkdir /nabu/assets
 ADD ./cmd/nabu/nabu /nabu/
 ADD ./assets /nabu/assets
 

--- a/internal/objects/copyobject.go
+++ b/internal/objects/copyobject.go
@@ -1,0 +1,36 @@
+package objects
+
+import (
+	"context"
+	"github.com/minio/minio-go/v7"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Copy is the generic object collection function
+func Copy(v1 *viper.Viper, mc *minio.Client, srcbucket, srcobject, dstbucket, dstobject string) error {
+
+	// Use-case 1: Simple copy object with no conditions.
+	// Source object
+	srcOpts := minio.CopySrcOptions{
+		Bucket: srcbucket,
+		Object: srcobject,
+	}
+
+	// Destination object
+	dstOpts := minio.CopyDestOptions{
+		Bucket: dstbucket,
+		Object: dstobject,
+	}
+
+	// Copy object call
+	uploadInfo, err := mc.CopyObject(context.Background(), dstOpts, srcOpts)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	log.Println("Successfully copied object:", uploadInfo)
+
+	return nil
+}

--- a/internal/objects/pipecopy.go
+++ b/internal/objects/pipecopy.go
@@ -20,7 +20,7 @@ import (
 // bucket:  source bucket  (and target bucket)
 // prefix:  source prefix
 // mc:  minio client pointer
-func PipeCopy(v1 *viper.Viper, mc *minio.Client, name, bucket, prefix string) error {
+func PipeCopy(v1 *viper.Viper, mc *minio.Client, name, bucket, prefix, destprefix string) error {
 	log.Printf("PipeCopy with name: %s   bucket: %s  prefix: %s", name, bucket, prefix)
 
 	pr, pw := io.Pipe()     // TeeReader of use?
@@ -66,7 +66,7 @@ func PipeCopy(v1 *viper.Viper, mc *minio.Client, name, bucket, prefix string) er
 				return
 			}
 
-			// TODO add the context into this fle  (then load to Jena withouth explicate graph)
+			// TODO add the context into this fle  (then load to Jena without explicate graph)
 			// g = fmt.Sprintf("urn:%s:%s", bucketName, strings.TrimSuffix(s2c, ".rdf"))
 			// func NQNewGraph(inquads, newctx string) (string, string, error) {
 
@@ -89,7 +89,7 @@ func PipeCopy(v1 *viper.Viper, mc *minio.Client, name, bucket, prefix string) er
 	// go function to write to minio from pipe
 	go func() {
 		defer lwg.Done()
-		_, err := mc.PutObject(context.Background(), bucket, fmt.Sprintf("%s/%s", "scratch", name), pr, -1, minio.PutObjectOptions{})
+		_, err := mc.PutObject(context.Background(), bucket, fmt.Sprintf("%s/%s", destprefix, name), pr, -1, minio.PutObjectOptions{})
 		//_, err := mc.PutObject(context.Background(), bucket, fmt.Sprintf("%s/%s", prefix, name), pr, -1, minio.PutObjectOptions{})
 		if err != nil {
 			log.Println(err)

--- a/internal/objects/removeobject.go
+++ b/internal/objects/removeobject.go
@@ -1,0 +1,24 @@
+package objects
+
+import (
+	"context"
+	"github.com/minio/minio-go/v7"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Remove is the generic object collection function
+func Remove(v1 *viper.Viper, mc *minio.Client, bucket, object string) error {
+	opts := minio.RemoveObjectOptions{
+		GovernanceBypass: true,
+		//VersionID:        "myversionid",
+	}
+
+	err := mc.RemoveObject(context.Background(), bucket, object, opts)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	return err
+}

--- a/internal/services/bulk/bulkLoader.go
+++ b/internal/services/bulk/bulkLoader.go
@@ -27,7 +27,7 @@ func BulkAssembly(v1 *viper.Viper, mc *minio.Client) error {
 	for p := range pa {
 		name := fmt.Sprintf("%s_bulk.rdf", baseName(path.Base(pa[p])))
 
-		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p]) // have this function return the object name and path, easy to load and remove then
+		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "scratch") // have this function return the object name and path, easy to load and remove then
 		//err = objects.MillerNG(name, bucketName, pa[p], mc) // have this function return the object name and path, easy to load and remove then
 
 		if err != nil {

--- a/internal/services/releases/bulkLoader.go
+++ b/internal/services/releases/bulkLoader.go
@@ -1,0 +1,76 @@
+package releases
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gleanerio/nabu/internal/prune"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/gleanerio/nabu/internal/objects"
+	"github.com/gleanerio/nabu/pkg/config"
+	"github.com/spf13/viper"
+
+	"github.com/minio/minio-go/v7"
+)
+
+// BulkRelease collects the objects from a bucket to load
+func BulkRelease(v1 *viper.Viper, mc *minio.Client) error {
+	log.Println("Release:BulkAssembly")
+	bucketName, _ := config.GetBucketName(v1)
+	objCfg, _ := config.GetObjectsConfig(v1)
+	pa := objCfg.Prefix
+
+	var err error
+
+	ol, err := prune.ObjectList(v1, mc, "graphs/latest")
+	if err != nil {
+		return err
+	}
+
+	for o := range ol {
+		for p := range pa {
+			if strings.Contains(ol[o], baseName(path.Base(pa[p]))) {
+				// move the match from graphs/latest to graphs/archive
+				fmt.Println(ol[o])
+				// copy it and change the prefix path from "latest" to "archive"
+				err = objects.Copy(v1, mc, bucketName, ol[o], bucketName, strings.Replace(ol[o], "latest", "archive", 1))
+				if err != nil {
+					log.Println(err)
+					return err
+				}
+				// remove it
+				err = objects.Remove(v1, mc, bucketName, ol[o])
+				if err != nil {
+					log.Println(err)
+					return err
+				}
+			}
+		}
+	}
+
+	for p := range pa {
+		const layout = "2006-01-02-15-04-05"
+		t := time.Now()
+		name := fmt.Sprintf("%s_%s_release.rdf", baseName(path.Base(pa[p])), t.Format(layout))
+
+		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "graphs/latest") // have this function return the object name and path, easy to load and remove then
+		//err = objects.MillerNG(name, bucketName, pa[p], mc) // have this function return the object name and path, easy to load and remove then
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func baseName(s string) string {
+	n := strings.LastIndexByte(s, '.')
+	if n == -1 {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/services/releases/bulkLoader.go
+++ b/internal/services/releases/bulkLoader.go
@@ -32,7 +32,9 @@ func BulkRelease(v1 *viper.Viper, mc *minio.Client) error {
 
 	for o := range ol {
 		for p := range pa {
-			if strings.Contains(ol[o], baseName(path.Base(pa[p]))) {
+			sp := strings.Split(pa[p], "/")
+			spj := strings.Join(sp, "")
+			if strings.Contains(ol[o], baseName(path.Base(spj))) {
 				// move the match from graphs/latest to graphs/archive
 				fmt.Println(ol[o])
 				// copy it and change the prefix path from "latest" to "archive"
@@ -52,13 +54,13 @@ func BulkRelease(v1 *viper.Viper, mc *minio.Client) error {
 	}
 
 	for p := range pa {
+		sp := strings.Split(pa[p], "/")
+		spj := strings.Join(sp, "")
 		const layout = "2006-01-02-15-04-05"
 		t := time.Now()
-		name := fmt.Sprintf("%s_%s_release.rdf", baseName(path.Base(pa[p])), t.Format(layout))
+		name := fmt.Sprintf("%s_%s_release.rdf", baseName(path.Base(spj)), t.Format(layout))
 
 		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "graphs/latest") // have this function return the object name and path, easy to load and remove then
-		//err = objects.MillerNG(name, bucketName, pa[p], mc) // have this function return the object name and path, easy to load and remove then
-
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/release.go
+++ b/pkg/cli/release.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/gleanerio/nabu/pkg"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+// checkCmd represents the check command
+var releaseCmd = &cobra.Command{
+	Use:   "release",
+	Short: "nabu release command",
+	Long:  `Generate releases for the indexes sources and also a master release`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := pkg.Release(viperVal, mc)
+		if err != nil {
+			log.Println(err) // was log.Fatal which seems odd
+			os.Exit(1)
+		}
+		os.Exit(0)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(releaseCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// checkCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// checkCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/pkg/release.go
+++ b/pkg/release.go
@@ -1,0 +1,31 @@
+package pkg
+
+import (
+	"github.com/gleanerio/nabu/internal/objects"
+	"github.com/gleanerio/nabu/internal/services/releases"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/viper"
+
+	"github.com/minio/minio-go/v7"
+)
+
+func Release(v1 *viper.Viper, mc *minio.Client) error {
+	//err := bulk.ObjectAssembly(v1, mc)
+	err := releases.BulkRelease(v1, mc)
+
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}
+
+// used by glcon in gleaner. Need to develop a more common config for the services (aka s3, graph, etc)
+// cannot pass a nabu config to the gleaner code to create a minio client, and have it work
+func NabuRelease(v1 *viper.Viper) error {
+	mc, err := objects.MinioConnection(v1)
+	if err != nil {
+		log.Fatal("cannot connect to minio: %s", err)
+	}
+	return Release(v1, mc)
+}


### PR DESCRIPTION
@valentinedwv here is the code I did the other day.   It is still a bit basic but functional...  

It builds a release graph for each provider in graphs/latest

First it attempts to move a groups graph from graphs/latest to graphs/archive

I've tested it with commands like

```
go run ../../cmd/nabu/main.go --cfg ./oihcore_testing.yaml release --prefix summoned/edmo
```




