### PR TITLE
updates to support quads in the release graph function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ nabu:
 	cd cmd/nabu; \
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 env go build -o nabu
 
-releases: nabu
-
 docker:
 	podman build  --tag="fils/nabu:$(VERSION)"  --file=./build/Dockerfile .
 
@@ -19,3 +17,5 @@ publish:
 	docker tag fils/nabu:$(VERSION) fils/nabu:latest
 	docker push fils/nabu:$(VERSION) ; \
 	docker push fils/nabu:latest
+
+releases: nabu docker dockerpush publish

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -5,6 +5,14 @@ minio:
   accesskey: akey
   secretkey: skey
   bucket: gleaner2
+context:
+  cache: true
+  strict: true
+contextmaps:
+  - prefix: "https://schema.org/"
+    file: "./assets/schemaorg-current-https.jsonld"  # wget http://schema.org/docs/jsonldcontext.jsonld
+  - prefix: "http://schema.org/"
+    file: "./assets/schemaorg-current-http.jsonld"  # wget http://schema.org/docs/jsonldcontext.jsonld
 objects:
   domain: us-east-1
   prefix:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -4,7 +4,7 @@ minio:
   ssl: false
   accesskey: akey
   secretkey: skey
-  bucket: gleaner2
+  bucket: gleaner
 context:
   cache: true
   strict: true
@@ -16,19 +16,14 @@ contextmaps:
 objects:
   domain: us-east-1
   prefix:
-    - milled/iris
-    - prov/iris
+    - summoned/providera
+    - prov/providera
     - org
-  prefixoff:
-    - summoned/aquadocs
-    - prov/aquadocs
-    - milled/opentopography
-    - prov/opentopography
 sparql:
   endpoint: http://localhost/blazegraph/namespace/earthcube/sparql
   endpointBulk: http://coreos.lan:3030/testing/data
+  endpointMethod: POST
+  contentType: application/n-quads
   authenticate: false
   username: ""
   password: ""
-txtaipkg:
-  endpoint: http://0.0.0.0:8000

--- a/decisions/0001-URN-decision.md
+++ b/decisions/0001-URN-decision.md
@@ -10,18 +10,29 @@ Proposed
 
 URNs for the graph URI are set in the file internal/graph/mintURN.go
 
+current
+```
+urn:{bucket}:{provider}:{sha}
+```
+
+proposed
+```
+urn:gleanerio:{network}:{provider}:{sha}
+```
+
+
 ## Decision
 
 Old URNs were varationas on 
 
 ```rdf
-urn:gleaner.oih:summoned:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
+urn:gleaner.io:summoned:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
 ```
 
 or
 
 ```rdf
-urn:gleaner.oih:milled:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
+urn:gleaner.io:milled:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
 ```
 
 The milled and summoned elements were pointless and led to confusion and were not 
@@ -30,7 +41,7 @@ really important in terms of getting to the object.
 The new desired URN pattern is 
 
 ```rdf
-urn:gleaner.oh:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
+urn:gleaner.io:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
 ```
 
 ## Consequences

--- a/decisions/0001-URN-decision.md
+++ b/decisions/0001-URN-decision.md
@@ -37,3 +37,5 @@ urn:gleaner.oh:edmo:0255293683036aac2a95a2479cc841189c0ac3f8
 
 This impacts gleaner in the generation of prov which will need to use this same pattern
 to fill out the prov records.  
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 Nabu primarily is a tool for reading from an S3 object store and writing 
 to a triplestore.  The object stores can be any S3 compliant object stores
-so Google Cloud Storage, Wasabi, or others.   For most cases I am using
+so AWS S3,  Google Cloud Storage, Wasabi, or others.   For most cases I am using
 Minio, an open source S3 object store. 
 
 Similarly, the triplestore can be any standards compliant triplestore.  Here
@@ -13,35 +13,13 @@ the primary standards we need implemented include
 * SPARQL 1.1 with Update support
 * SPARQL 1.1 over HTTP
 
+As noted in the documentation late, if using the _bulk_ upload feature you 
+need set the METHOD and ContentType your triplestore will expect. 
+
 ## Basic operations
 
-Config file example
-
-```
-minio:
-  address: localhost
-  port: 9000
-  ssl: false
-  accesskey: akey
-  secretkey: skey
-  bucket: gleaner2
-objects:
-  domain: us-east-1
-  prefix:
-  - milled/iris
-  - prov/iris
-  - org
-  prefixoff:
-  - summoned/aquadocs
-  - prov/aquadocs
-  - milled/opentopography
-  - prov/opentopography
-sparql:
-  endpoint: http://localhost/blazegraph/namespace/earthcube/sparql
-  authenticate: false
-  username: ""
-  password: ""
-```
+Nabu needs a configuration file.  A template for this can be seen 
+in [example.yaml](../config/example.yaml).  
 
 Commands are like the following:
 ### Help
@@ -53,19 +31,19 @@ The mode "prefix" in Nabu is used for loading a S3 object prefix
 path into a triplestore
 
 ```bash
-nabu --cfg /nabu/wd/nabuconfig.yaml  prune
+nabu --cfg example.yaml  prune
 
-nabu --cfg /nabu/wd/nabuconfig.yaml  prune --prefix summoned/amgeo
+nabu --cfg example.yaml  prune --prefix summoned/amgeo
 ```
 
 ```bash
-nabu --cfg ./oihcore_testing.yaml prefix
+nabu --cfg .example.yaml prefix
 
-nabu --cfg ./oihcore_testing.yaml prefix -prefix summoned/amgeo
+nabu --cfg example.yaml prefix -prefix summoned/amgeo
 
 ```
-eg
-```
+
+```bash
 nabu prefix --cfg ../gleaner/configs/nabu
 ```
 and gleaner generated configuration: 
@@ -82,21 +60,107 @@ The mode "prune" in Nabu is to sync a prefix to the graph (remove graphs no long
 
 Note that updated graphs become new objects, since the object name is the SHA256 of the object
 
-```
+
+```bash
 nabu prune --cfg file 
 ```
 and gleaner generated configuration:
-```
+```bash
 nabu prefix --cfgPath directory --cfgName name 
 ```
 eg use generated
-```
+```bash
 nabu prefix --cfgPath ../gleaner/configs --cfgName local 
+```
+
+
+### Bulk
+
+This commands loads all the triples into the triplestore using the bulk load 
+approach.  This is a SPARQL UPDATE call, vs the classic SPARQL command.  Nabu
+will generate all the triples into a temporary file and then use that load into the 
+triplestore.  This file will be removed after it is used. 
+
+Required configuration entry
+
+```yaml
+sparql:
+  endpoint: http://localhost/blazegraph/namespace/earthcube/sparql
+  endpointBulk: http://coreos.lan:3030/testing/data
+  endpointMethod: PUT
+  contentType: application/n-quads
+  authenticate: false
+  username: ""
+  password: ""
+```
+The bulk loading endpoint for many triplestores is different from the default
+SPARQL endpoint.  Also, different vendors will likely require different methods
+and content type.  These are only needed in the case where you are using the
+_bulk_ command in Nabu.  For example:
+
+GraphDB example ([reference](https://graphdb.ontotext.com/documentation/10.2/))
+```yaml
+endpointBulk: http://example.org:7200/repositories/testing/statements
+endpointMethod: PUT
+contentType: application/n-quads
+```
+
+Jena example ([reference](https://jena.apache.org/tutorials/index.html))
+```yaml
+endpointBulk: http://example.org:3030/testing/data
+endpointMethod: PUT
+contentType: application/n-quads
+```
+
+Blazegraph example ([reference](https://github.com/blazegraph/database/wiki/REST_API))
+```yaml
+endpointBulk: http://example.org9090/blazegraph/namespace/kb/sparql
+endpointMethod: POST
+contentType: text/x-nquads
+```
+
+
+
+Bulk load  the  specified source in the objects-prefix node
+of the configuration file, use the _--prefix_ flag to specify the source.
+
+```bash
+nabu bulk --cfg ./example.yaml  --prefix summoned/providera
+```
+
+Bulk load all the sources defined in the objects-prefix node
+of the configuration file.
+
+```bash
+nabu bulk --cfg ./example.yaml   
+```
+
+
+### Release
+
+The _release_ command is used to build out release graphs.  These are the entire
+set of objects associated with a provider, rolled up in one file.  These are done 
+as nquads with the named graph following the pattern as defined in the ADR
+[0001-URN-decision](https://github.com/gleanerio/nabu/blob/dev/decisions/0001-URN-decision.md).
+
+
+To build a release graphs for a specified source in the objects-prefix node
+of the configuration file, use the _--prefix_ flag to specify the source.  
+
+```bash
+nabu release --cfg ./example.yaml  --prefix summoned/providera
+```
+
+To build all the release graphs for the sources defined in the objects-prefix node
+of the configuration file.
+
+```bash
+nabu release --cfg ./example.yaml   
 ```
 
 ### Object: load one object in the bucket/prefixes
 
-The mode "object" in Nabu is used for loading a S3 object 
+The mode "object" in Nabu is used for loading a S3 object
 path into a triplestore
 ```
 nabu object --cfg file objectId
@@ -114,10 +178,3 @@ eg use generated
 ```
 nabu object --cfgPath ../gleaner/configs --cfgName local milled/opentopography/ffa0df033bb3a8fc9f600c80df3501fe1a2dbe93.rdf
 ```
-
-## TODO
-
-- overview here of the basic config, source, app sink flow
-- The quad as prov pattern where the path to the triples, becomes
-the quad value 
- 

--- a/docs/sparql/allGraphs.rq
+++ b/docs/sparql/allGraphs.rq
@@ -2,11 +2,11 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-SELECT ?g
+SELECT DISTINCT ?g
 
 WHERE {
     graph ?g {
         ?s ?p ?o
     }
 }
-LIMIT 100
+LIMIT 1000

--- a/docs/sparql/allLimit100.rq
+++ b/docs/sparql/allLimit100.rq
@@ -4,6 +4,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 SELECT *
 WHERE {
-    ?s ?p ?o
+    graph ?g {
+        ?s ?p ?o
+    }
 }
 LIMIT 100

--- a/internal/graph/jsonldToNQ.go
+++ b/internal/graph/jsonldToNQ.go
@@ -18,7 +18,7 @@ func JSONLDToNQ(v1 *viper.Viper, jsonld string) (string, error) {
 		return "", err
 	}
 
-	triples, err := proc.ToRDF(myInterface, options) // returns triples but toss them, just validating
+	triples, err := proc.ToRDF(myInterface, options)
 	if err != nil {
 		log.Println("Error when transforming JSON-LD document to RDF:", err)
 		return "", err

--- a/internal/graph/skolemize.go
+++ b/internal/graph/skolemize.go
@@ -54,6 +54,7 @@ func Skolemization(nq, key string) (string, error) {
 
 	var err = scanner.Err()
 	if err != nil {
+		log.Errorf("Error decoding source: %s\n", key)
 		log.Error(err)
 	}
 

--- a/internal/graph/toFromRDF.go
+++ b/internal/graph/toFromRDF.go
@@ -1,0 +1,147 @@
+package graph
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/knakk/rdf"
+	"github.com/piprate/json-gold/ld"
+)
+
+// fmt.Println("---------------nq -> json-ld------------------")
+// jsonld, _ := nqToJSONLD(quads)
+
+// fmt.Println("--------------json-ld -> nq----------------")
+// nq, _ := jsonldToNQ(string(jsonld))
+
+// fmt.Println("------------nq -> nt + context----------------")
+// nt, g, _ := nqToNTCtx(nq)
+
+// fmt.Println("------------nt + ctx -> nq----------------")
+// nq2, _ := ntToNq(triples, "context")
+
+func NtToNq(nt, ctx string) (string, error) {
+	dec := rdf.NewTripleDecoder(strings.NewReader(nt), rdf.NTriples)
+	tr, err := dec.DecodeAll()
+	if err != nil {
+		log.Printf("Error decoding triples: %v\n", err)
+	}
+
+	// loop on tr and make a set of quads
+	var sa []string
+	for i := range tr {
+		q, err := makeQuad(tr[i], ctx)
+		if err != nil {
+			log.Println(err)
+		}
+		sa = append(sa, q)
+		//fmt.Print(q)
+	}
+
+	return strings.Join(sa, ""), err
+}
+
+// makeQuad I pulled this from my ObjectEngine code in case I needed to
+// use in the ntToNQ() function to add a context to each triple in turn.
+// It may not be needed/used in this code
+func makeQuad(t rdf.Triple, c string) (string, error) {
+	newctx, err := rdf.NewIRI(c) // this should be  c
+	ctx := rdf.Context(newctx)
+
+	q := rdf.Quad{t, ctx}
+
+	buf := bytes.NewBufferString("")
+
+	qs := q.Serialize(rdf.NQuads)
+	_, err = fmt.Fprintf(buf, "%s", qs)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), err
+}
+
+// NqToNTCtx  Converts quads to triples and return the graph name separately
+func NqToNTCtx(inquads string) (string, string, error) {
+	dec := rdf.NewQuadDecoder(strings.NewReader(inquads), rdf.NQuads)
+	tr, err := dec.DecodeAll()
+	if err != nil {
+		log.Printf("Error decoding triples: %v\n", err)
+	}
+
+	// loop on tr and make a set of triples
+	ntr := []rdf.Triple{}
+	for i := range tr {
+		ntr = append(ntr, tr[i].Triple)
+	}
+
+	// Assume context of first triple sis context of all triples
+	// TODO..   this is stupid if not dangers, at least return []string of all the contexts
+	// that were in the graph.
+	ctx := tr[0].Ctx
+	g := ctx.String()
+
+	outtriples := ""
+	buf := bytes.NewBufferString(outtriples)
+	enc := rdf.NewTripleEncoder(buf, rdf.NTriples)
+	err = enc.EncodeAll(ntr)
+	if err != nil {
+		log.Printf("Error encoding triples: %v\n", err)
+	}
+	err = enc.Close()
+	if err != nil {
+		return "", "", err
+	}
+
+	tb := bytes.NewBuffer([]byte(""))
+	for k := range ntr {
+		tb.WriteString(ntr[k].Serialize(rdf.NTriples))
+	}
+
+	return tb.String(), g, err
+}
+
+// NqToJSONLD convert quads to JSON-LD?  (or is this NT...  see next func)
+// Am I losing the context here (ie, no graph[]:)
+func NqToJSONLD(triples string) ([]byte, error) {
+	proc := ld.NewJsonLdProcessor()
+	options := ld.NewJsonLdOptions("")
+	// add the processing mode explicitly if you need JSON-LD 1.1 features
+	options.ProcessingMode = ld.JsonLd_1_1
+
+	doc, err := proc.FromRDF(triples, options)
+	if err != nil {
+		panic(err)
+	}
+
+	// ld.PrintDocument("JSON-LD output", doc)
+	b, err := json.MarshalIndent(doc, "", " ")
+
+	return b, err
+}
+
+func JsonldToNQ(jsonld string) (string, error) {
+	proc := ld.NewJsonLdProcessor()
+	options := ld.NewJsonLdOptions("")
+	// add the processing mode explicitly if you need JSON-LD 1.1 features
+	options.ProcessingMode = ld.JsonLd_1_1
+	options.Format = "application/n-quads"
+
+	var myInterface interface{}
+	err := json.Unmarshal([]byte(jsonld), &myInterface)
+	if err != nil {
+		log.Println("Error when transforming JSON-LD document to interface:", err)
+		return "", err
+	}
+
+	triples, err := proc.ToRDF(myInterface, options) // returns triples but toss them, just validating
+	if err != nil {
+		log.Println("Error when transforming JSON-LD document to RDF:", err)
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", triples), err
+}

--- a/internal/graph/urnToPrefix.go
+++ b/internal/graph/urnToPrefix.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// URNToPrefix concert a urn string to a valid prefix
+// URNToPrefix convert  urn string to a valid s3 prefix
 // So urn:gleaner.oih:edmo:00032788b3d1eecf4257bd8ffd42c5d56761a6bf
 // becomes gleaner.oih/[summoned]/edmo/00032788b3d1eecf4257bd8ffd42c5d56761a6bf.jsonld
 func URNToPrefix(urn, pathelement, suffix string) (string, error) {

--- a/internal/services/bulk/bulkLoader.go
+++ b/internal/services/bulk/bulkLoader.go
@@ -23,15 +23,9 @@ func BulkAssembly(v1 *viper.Viper, mc *minio.Client) error {
 
 	var err error
 
-	// Set "single file flag" to bypass skolemization, if is a single file the JSON-LD to RDF will correctly map blank nodes.
-	sf := true
-	if len(pa) > 1 {
-		sf = false
-	}
-
 	for p := range pa {
 		name := fmt.Sprintf("%s_bulk.rdf", baseName(path.Base(pa[p])))
-		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "scratch", sf) // have this function return the object name and path, easy to load and remove then
+		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "scratch") // have this function return the object name and path, easy to load and remove then
 		//err = objects.MillerNG(name, bucketName, pa[p], mc) // have this function return the object name and path, easy to load and remove then
 		if err != nil {
 			return err

--- a/internal/services/bulk/bulkLoader.go
+++ b/internal/services/bulk/bulkLoader.go
@@ -24,10 +24,17 @@ func BulkAssembly(v1 *viper.Viper, mc *minio.Client) error {
 
 	var err error
 
+	// Set and use a "single file flag" to bypass skolimaization since if it is a single file
+	// the JSON-LD to RDF will correctly map blank nodes.
+	sf := true
+	if len(pa) > 1 {
+		sf = false
+	}
+
 	for p := range pa {
 		name := fmt.Sprintf("%s_bulk.rdf", baseName(path.Base(pa[p])))
 
-		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "scratch") // have this function return the object name and path, easy to load and remove then
+		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "scratch", sf) // have this function return the object name and path, easy to load and remove then
 		//err = objects.MillerNG(name, bucketName, pa[p], mc) // have this function return the object name and path, easy to load and remove then
 
 		if err != nil {

--- a/internal/services/bulk/function.go
+++ b/internal/services/bulk/function.go
@@ -2,8 +2,10 @@ package bulk
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"github.com/gleanerio/nabu/pkg/config"
+	"io"
 	"net/http"
 	"strings"
 
@@ -16,25 +18,39 @@ import (
 	"github.com/minio/minio-go/v7"
 )
 
-func docfunc(v1 *viper.Viper, mc *minio.Client, bucketName string, item string, endpoint string) (string, error) {
-	log.Printf("Jena docfunc called with %s%s", bucketName, item)
-	log.Println(endpoint)
+func docfunc(v1 *viper.Viper, mc *minio.Client, bucketName string, item string) (string, error) {
+	spql, err := config.GetSparqlConfig(v1)
+	if err != nil {
+		return "", err
+	}
+	ep := spql.EndpointBulk
+	md := spql.EndpointMethod
+	ct := spql.ContentType
+
+	// check for the required bulk endpoint, no need to move on from here
+	if spql.EndpointBulk == "" {
+		return "", errors.New("The configuration file lacks an endpointBulk entry")
+	}
+
+	log.Printf("Object %s:%s for %s with method %s type %s", bucketName, item, ep, md, ct)
 
 	b, _, err := objects.GetS3Bytes(mc, bucketName, item)
 	if err != nil {
 		return "", err
 	}
 
-	// TODO skolemize the RDF here..
-	// unless bulk loading, in which case it needs to be done prior to here and this should be skipped
-	// the "bulk" load function might be different too
-
+	// NOTE:   commented out, but left.  Since we are loading quads, no need for a graph.
+	// If (when) we add back in ntriples as a version, this could be used to build a graph for
+	// All the triples in the bulk file to then load as triples + general context (graph)
+	// Review if this graph g should b here since we are loading quads
+	// I don't think it should b.   validate with all the tested triple stores
 	bn := strings.Replace(bucketName, ".", ":", -1) //why is this here?
 	g, err := graph.MakeURN(item, bn)
 	if err != nil {
 		log.Error("gets3Bytes %v\n", err)
-		// should this just return. since on this error things are not good
+		return "", err // Assume return. since on this error things are not good?
 	}
+	url := fmt.Sprintf("%s?graph=%s", ep, g)
 
 	// check if JSON-LD and convert to RDF
 	if strings.Contains(item, ".jsonld") {
@@ -45,10 +61,11 @@ func docfunc(v1 *viper.Viper, mc *minio.Client, bucketName string, item string, 
 		b = []byte(nb)
 	}
 
-	url := fmt.Sprintf("%s?graph=%s", endpoint, g)
-
-	req, err := http.NewRequest("PUT", url, bytes.NewReader(b))
-	req.Header.Set("Content-Type", "application/n-quads")
+	req, err := http.NewRequest(md, url, bytes.NewReader(b))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", ct) // needs to be x-nquads for blaze, n-quads for jena and graphdb
 	req.Header.Set("User-Agent", "EarthCube_DataBot/1.0")
 
 	client := &http.Client{}
@@ -56,18 +73,22 @@ func docfunc(v1 *viper.Viper, mc *minio.Client, bucketName string, item string, 
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+		}
+	}(resp.Body)
 
 	log.Println(resp)
-	body, err := ioutil.ReadAll(resp.Body) // return body if you want to debugg test with it
+	body, err := io.ReadAll(resp.Body) // return body if you want to debugg test with it
 	if err != nil {
 		log.Println(string(body))
 		return string(body), err
 	}
 
-	// TESTING
+	// report
 	log.Println(string(body))
-	log.Printf("success: %s : %d  : %s\n", item, len(b), endpoint)
+	log.Printf("success: %s : %d  : %s\n", item, len(b), ep)
 
 	return string(body), err
 }

--- a/internal/services/bulk/function.go
+++ b/internal/services/bulk/function.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gleanerio/nabu/pkg/config"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/gleanerio/nabu/pkg/config"
 
 	"github.com/gleanerio/nabu/internal/graph"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/minio/minio-go/v7"
 )
 
+// docfunc needs to be renamed to something like BulkUpate and made exported
+// This functions could be used to load stored release graphs to the graph database
 func docfunc(v1 *viper.Viper, mc *minio.Client, bucketName string, item string) (string, error) {
 	spql, err := config.GetSparqlConfig(v1)
 	if err != nil {
@@ -44,7 +47,7 @@ func docfunc(v1 *viper.Viper, mc *minio.Client, bucketName string, item string) 
 	// All the triples in the bulk file to then load as triples + general context (graph)
 	// Review if this graph g should b here since we are loading quads
 	// I don't think it should b.   validate with all the tested triple stores
-	bn := strings.Replace(bucketName, ".", ":", -1) //why is this here?
+	bn := strings.Replace(bucketName, ".", ":", -1) // convert to urn : values, buckets with . are not valid IRIs
 	g, err := graph.MakeURN(item, bn)
 	if err != nil {
 		log.Error("gets3Bytes %v\n", err)

--- a/internal/services/releases/bulkLoader.go
+++ b/internal/services/releases/bulkLoader.go
@@ -32,6 +32,7 @@ func BulkRelease(v1 *viper.Viper, mc *minio.Client) error {
 		return err
 	}
 
+	// Let's move the current bulk graph to archive and clear the way for a new release graph
 	for o := range ol {
 		for p := range pa {
 			sp := strings.Split(pa[p], "/")
@@ -55,13 +56,6 @@ func BulkRelease(v1 *viper.Viper, mc *minio.Client) error {
 		}
 	}
 
-	// Set and use a "single file flag" to bypass skolimaization since if it is a single file
-	// the JSON-LD to RDF will correctly map blank nodes.
-	sf := true
-	if len(pa) > 1 {
-		sf = false
-	}
-
 	for p := range pa {
 		sp := strings.Split(pa[p], "/")
 		spj := strings.Join(sp, "")
@@ -69,7 +63,7 @@ func BulkRelease(v1 *viper.Viper, mc *minio.Client) error {
 		t := time.Now()
 		name := fmt.Sprintf("%s_%s_release.nq", baseName(path.Base(spj)), t.Format(layout))
 
-		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "graphs/latest", sf) // have this function return the object name and path, easy to load and remove then
+		err = objects.PipeCopy(v1, mc, name, bucketName, pa[p], "graphs/latest") // have this function return the object name and path, easy to load and remove then
 		if err != nil {
 			return err
 		}

--- a/pkg/config/sparql.go
+++ b/pkg/config/sparql.go
@@ -6,20 +6,24 @@ import (
 )
 
 type Sparql struct {
-	Endpoint     string
-	EndpointBulk string
-	Authenticate bool
-	Username     string
-	Password     string
+	Endpoint       string
+	EndpointBulk   string
+	EndpointMethod string
+	ContentType    string
+	Authenticate   bool
+	Username       string
+	Password       string
 }
 
 var sparqlTemplate = map[string]interface{}{
 	"sparql": map[string]string{
-		"endpoint":     "http://coreos.lan:3030/testing/sparql",
-		"endpointBulk": "http://coreos.lan:3030/testing/data",
-		"authenticate": "False",
-		"username":     "",
-		"password":     "",
+		"endpoint":       "http://example.org:3030/testing/sparql",
+		"endpointBulk":   "http://example.org:3030/testing/data",
+		"endpointMethod": "POST",
+		"contentType":    "application/n-quads",
+		"authenticate":   "False",
+		"username":       "",
+		"password":       "",
 	},
 }
 
@@ -35,6 +39,8 @@ func ReadSparqlConfig(viperSubtree *viper.Viper) (Sparql, error) {
 	}
 	viperSubtree.BindEnv("endpoint", "SPARQL_ENDPOINT")
 	viperSubtree.BindEnv("endpointBulk", "SPARQL_ENDPOINTBULK")
+	viperSubtree.BindEnv("endpointMethod", "SPARQL_ENDPOINTMETHOD")
+	viperSubtree.BindEnv("contentType", "SPARQL_CONTENTTYPE")
 	viperSubtree.BindEnv("authenticate", "SPARQL_AUTHENTICATE")
 	viperSubtree.BindEnv("username", "SPARQL_USERNAME")
 	viperSubtree.BindEnv("password", "SPARQL_PASSWORD")

--- a/scripts/countInSummoned.sh
+++ b/scripts/countInSummoned.sh
@@ -64,5 +64,3 @@ done
 echo -e "${total} \t total"
 
 
-
-


### PR DESCRIPTION
Changed include

* ADR: https://github.com/gleanerio/nabu/blob/dev/decisions/0001-URN-decision.md
* bulkloader  (both bulk and release) now checks if single file, skips skolimization if true.  Not needed with 
a single file since no chance for blank node URN collision
* example.yaml updated to include the context parameters and contextmap node
* comment removed in jsonldToNQ.go  (pointless to do, but I did it anyway)  ;) 
* mod ldproc.go to read and use the context map node in the config
* Makefile order changed, for no good reason
* pipcopy update to support quads as output
* skolemize.go comment removed to simply pad the number of files in the commit.  ;) 
* urnToPrefix   more pointless comment updates to make me feel good
* tofromRDF.go added which does some various RDF transforms, there are some unused functions in here (JsonldToNQ,NqToJSONLD,NqToNTCtx)  but left them in for now. 


So really only pipecopy, ldproc toFromRDF and the two bulkloader files have any changes of value in them.